### PR TITLE
Added changeable Line Endings to RS232-Bricklet Plugin GUI

### DIFF
--- a/src/brickv/plugin_system/plugins/rs232/TFHexValidator.py
+++ b/src/brickv/plugin_system/plugins/rs232/TFHexValidator.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Hex Validator for Tinkerforge Brickv RS232 Plugin
+Copyright (C) 2015 Vincent Szurma <vincent@szurma.de>
+
+TFHexValidator.py: Validator for Hex Inputs
+Written for Tinkerforge RS232-Bricklet Brickv-Plugin
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public
+License along with this program; if not, write to the
+Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.
+"""
+
+from PyQt4.QtGui import QValidator
+from PyQt4.QtCore import QRegExp
+
+class TFHexValidator(QValidator):
+    def __init__(self):
+        QValidator.__init__(self)
+
+    def validate(self, _input, _pos):
+        re_valid  = QRegExp('^([0-9A-Fa-f]{2})*$')
+        re_interm = QRegExp('^([0-9A-Fa-f]{2})*([0-9A-Fa-f]{1})$')
+
+        _input=_input.upper()
+
+        if re_valid.exactMatch(_input):
+            return (QValidator.Acceptable, _input, _pos)
+        elif re_interm.exactMatch(_input):
+            return (QValidator.Intermediate, _input, _pos)
+
+        return (QValidator.Invalid, _input, _pos)
+
+
+    def fixup(self, _input):
+        if len(_input)%2 == 1:
+            return _input[:-1]+'0'+ _input[-1:]
+
+        return ''

--- a/src/brickv/plugin_system/plugins/rs232/ui/rs232.ui
+++ b/src/brickv/plugin_system/plugins/rs232/ui/rs232.ui
@@ -38,7 +38,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Binary</string>
+         <string>Hex</string>
         </property>
        </item>
       </widget>
@@ -97,6 +97,70 @@
        </property>
        <property name="insertPolicy">
         <enum>QComboBox::InsertAtBottom</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="line_ending_combobox">
+       <property name="toolTip">
+        <string>Line Ending</string>
+       </property>
+       <property name="currentIndex">
+        <number>3</number>
+       </property>
+       <item>
+        <property name="text">
+         <string/>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>\n</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>\r</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>\r\n</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>\n\r</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>\0</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Hex:</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="line_ending_lineedit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Line Endings are now changeable to None, \n, \r, \r\n, \n\r, \0 or Hex-Input e.g \x01\x02 through a combobox and an LineEdit right of the input LineEdit.