### PR TITLE
Fixes for package build

### DIFF
--- a/src/brickv/bin_validator.py
+++ b/src/brickv/bin_validator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 brickv (Brick Viewer)

--- a/src/brickv/hex_validator.py
+++ b/src/brickv/hex_validator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 brickv (Brick Viewer)

--- a/src/brickv/object_creator.py
+++ b/src/brickv/object_creator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 brickv (Brick Viewer)

--- a/src/brickv/plugin_system/plugins/red/build_serviceproviders.py
+++ b/src/brickv/plugin_system/plugins/red/build_serviceproviders.py
@@ -31,8 +31,14 @@ import urllib.error
 import xml.etree.ElementTree as ET
 from pprint import pformat
 
-XML_URL = 'https://git.gnome.org/browse/mobile-broadband-provider-info/plain/serviceproviders.xml'
-ISO3166_URL = 'https://salsa.debian.org/iso-codes-team/iso-codes/raw/master/data/iso_3166-1.json'
+try:
+    XML_URL = 'file://{0}'.format(os.environ['SERVICEPROVIDERS_XML_PATH'])
+except KeyError:
+    XML_URL = 'https://git.gnome.org/browse/mobile-broadband-provider-info/plain/serviceproviders.xml'
+try:
+    ISO3166_URL = 'file://{0}'.format(os.environ['ISOCODES_JSON_PATH'])
+except KeyError:
+    ISO3166_URL = 'https://salsa.debian.org/iso-codes-team/iso-codes/raw/master/data/iso_3166-1.json'
 DATA_FILE = 'serviceprovider_data.py'
 
 try:

--- a/src/brickv/qhexedit.py
+++ b/src/brickv/qhexedit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011 Loic Jaquemet loic.jaquemet+python@gmail.com


### PR DESCRIPTION
This pull request removes rpm-lint errors for opensuse and allows to select local installed iso codes and mobile providers files, also for opensuse, where no internet access is possible during package build process.