### PR TITLE
red: Sort input file list

### DIFF
--- a/src/brickv/plugin_system/plugins/red/build_scripts.py
+++ b/src/brickv/plugin_system/plugins/red/build_scripts.py
@@ -35,7 +35,7 @@ try:
     build_script_path = os.path.dirname(os.path.realpath(__file__))
     scripts = []
 
-    for script in glob.glob(os.path.join(build_script_path, 'scripts', '*.py')):
+    for script in sorted(glob.glob(os.path.join(build_script_path, 'scripts', '*.py'))):
         scripts.append(script)
         lines = []
 
@@ -57,7 +57,7 @@ try:
         with open(script + '_prepared', 'w') as f:
             f.writelines(lines)
 
-    for script in glob.glob(os.path.join(build_script_path, 'scripts', '*.sh')):
+    for script in sorted(glob.glob(os.path.join(build_script_path, 'scripts', '*.sh'))):
         scripts.append(script)
         lines = []
 


### PR DESCRIPTION
Sort input file list
so that `script_data.py` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.