### PR TITLE
udev-rules: Fix ATTR assignment

### DIFF
--- a/src/build_data/linux/brick-flash/lib/udev/rules.d/99-tinkerforge-brick-flash.rules
+++ b/src/build_data/linux/brick-flash/lib/udev/rules.d/99-tinkerforge-brick-flash.rules
@@ -1,3 +1,3 @@
 # Disable autosuspend for Tinkerforge Brick bootloader mode
 # Bootloader otherwise stops working the first time autosuspend is enabled
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTR{idProduct}=="6124", TEST=="power/autosuspend", ATTR{power/autosuspend}:="-1"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTR{idProduct}=="6124", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"

--- a/src/build_data/linux/brickv/lib/udev/rules.d/99-tinkerforge-brickv.rules
+++ b/src/build_data/linux/brickv/lib/udev/rules.d/99-tinkerforge-brickv.rules
@@ -1,3 +1,3 @@
 # Disable autosuspend for Tinkerforge Brick bootloader mode
 # Bootloader otherwise stops working the first time autosuspend is enabled
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTR{idProduct}=="6124", TEST=="power/autosuspend", ATTR{power/autosuspend}:="-1"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTR{idProduct}=="6124", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"


### PR DESCRIPTION
according to http://reactivated.net/writing_udev_rules.html ":=" is not a valid assignment for udev rules.